### PR TITLE
pre-allocate dist

### DIFF
--- a/R/simulate.r
+++ b/R/simulate.r
@@ -24,7 +24,7 @@ chain_sim <- function(n, offspring, stat = c("size", "length"), infinite = Inf,
     }
 
     ## next, simulate n chains
-    dist <- c()
+    dist <- integer(n)
     for (i in seq_len(n)) {
         stat_track <- 1 ## track length or size (depending on `stat`)
         state <- 1


### PR DESCRIPTION
Growing a vector in R tends to be slow. This process will run faster due to the pre-allocation:

```r
Unit: relative
                                                                  expr      min       lq     mean   median       uq      max neval cld
            { slow <- c() for (i in seq(1e+06)) slow[i] <- 1 } 5.156572 5.071423 5.084367 5.023986 5.271332 3.261024   100   b
 { fast <- integer(1e+06) for (i in seq(1e+06)) fast[i] <- 1 } 1.000000 1.000000 1.000000 1.000000 1.000000 1.000000   100  a
```